### PR TITLE
fix: Get rid of error on logout

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -66,6 +66,5 @@ header {
   .home-button,
   .home-button-disabled {
     flex: 1;
-    padding-left: 40px;
   }
 }

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -18,15 +18,17 @@ export default function App() {
     <div className="App">
       <header>
         {location.pathname !== '/login' ? (
-          <Link className='home-button' to={'/'}>
-            <h1 className='app-title'>Tavern Keeper</h1>
-          </Link>
+          <>
+            <Link className='home-button' to={'/'}>
+              <h1 className='app-title'>Tavern Keeper</h1>
+            </Link>
+            <Navigation setUserName={setUserName} />
+          </>
         ) : (
           <div className='home-button-disabled'>
             <h1 className='app-title'>Tavern Keeper</h1>
           </div>
         )}
-        <Navigation />
       </header>
       <Routes>
         <Route path="/" element={<Home userName={userName} />} />

--- a/src/components/Navigation/Navigation.css
+++ b/src/components/Navigation/Navigation.css
@@ -57,7 +57,6 @@
     align-items: center;
     justify-content: space-evenly;
     flex: 2;
-    padding-right: 20px;
   }
 
   .EncounterBuilderButton,

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -4,7 +4,7 @@ import './Navigation.css';
 import EncounterBuilderButton from '../EncounterBuilderButton/EncounterBuilderButton';
 import LogoutButton from '../LogoutButton/LogoutButton';
 
-const Navigation = () => {
+const Navigation = ({ setUserName }) => {
   const location = useLocation();
 
   return (
@@ -12,7 +12,7 @@ const Navigation = () => {
       {location.pathname !== '/login' &&
         <div className='navigation-buttons'>
           <EncounterBuilderButton />
-          <LogoutButton />
+          <LogoutButton setUserName={setUserName} />
         </div>}
     </div>
   );


### PR DESCRIPTION
# Description
- Updates conditional in App.jsx to render nav component only if not on login page
- Passes `setUserName` down through nav component to logout button component
- Tweaks styling to make header elements still look good whether or not the buttons are there

# Screenshot(s)
Error message:
![Screenshot 2024-02-09 at 9 20 54 AM](https://github.com/Tavern-Keeper-2308/tavern-keeper-fe/assets/133910120/ff411d9a-f21e-44f3-805f-c77874147ed5)

# Notes
- This change makes the app title move to the center of the header when the buttons aren't there, regardless of breakpoint. On all other pages, the app title still sits on the left on desktop views. I don't think it's worth it to spend more time on the css to force the app title over to the left when there are no buttons. I also think it looks pretty nice in the middle anyway, when there are no buttons. 

# Checklist
- [X] My PR has an appropriately descriptive and concise title.
- [X] I ran the code locally and verified that there are no visible errors.
- [X] fix: My PR clearly describes the bug I'm fixing and why.